### PR TITLE
Install python2-avocado-plugins-varianter-yaml-to-mux in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf install -y \
   genisoimage \
   openssh-clients \
   python2-avocado \
+  python2-avocado-plugins-varianter-yaml-to-mux \
   qemu-system-x86
 
 RUN useradd -m tester


### PR DESCRIPTION
Plugins were split into subpackages in python2-avocado-46.0-2

Fixes: avocado run: error: unrecognized arguments: -m image:images.yml