### PR TITLE
run-tests: check PR author instead of branch owner

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -253,7 +253,7 @@ def choose_task(gh, repos, images):
     tasks = []
     for owner, repo in repos:
         for pull in gh.get(f'repos/{owner}/{repo}/pulls').json():
-            author = pull['head']['user']['login']
+            author = pull['user']['login']
             head = pull['head']['sha']
             number = pull['number']
 


### PR DESCRIPTION
We only run tests when the branch owner has write permissions to the
repository under test.

Some people seem to prefer opening pull requests from a branch in the
upstream repository instead of their fork. This made our test fail,
because the branch owner is the organization in that case and GitHub
doesn't seem to have permissions for organizations.

Check the author of the pull request instead to support this use case.