### PR TITLE
Allow to specify arbitrary Ansible playbook in config.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ accessible URL for these results. For example:
     {
       "name": "fedora-28",
       "source": "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2",
-      "setup": "sudo dnf install -yq python2 python2-dnf libselinux-python"
+      "setup": [
+        {
+          "name": "Setup",
+          "hosts": "all",
+          "become": true,
+          "gather_facts": false,
+          "tasks": [
+            {"raw": "sudo dnf install -yq python2 python2-dnf libselinux-python"}
+          ]
+        }
+      ]
     },
     {
       "name": "centos-6",
@@ -54,6 +64,8 @@ accessible URL for these results. For example:
   }
 }
 ```
+
+The `setup` key contains either a list of Ansible plays which will be saved as a playbook and executed before the test run, or a single shell command which will be executed using the Ansible `raw` module (so the two examples above are exactly equivalent).
 
 The container needs a `/secrets` mount, which must contain these files:
 

--- a/test/run-tests
+++ b/test/run-tests
@@ -218,16 +218,20 @@ class Task:
 
             setup_plays = [fail_localhost]
             if 'setup' in self.image:
-                play = {
-                    'name': 'Setup',
-                    'hosts': 'all',
-                    'become': True,
-                    'gather_facts': False,
-                    'tasks': [
-                        {'raw': self.image['setup']}
-                    ]
-                }
-                setup_plays.append(play)
+                setup = self.image['setup']
+                if isinstance(self.image['setup'], str):
+                    play = {
+                        'name': 'Setup',
+                        'hosts': 'all',
+                        'become': True,
+                        'gather_facts': False,
+                        'tasks': [
+                            {'raw': self.image['setup']}
+                        ]
+                    }
+                    setup_plays.append(play)
+                else:
+                    setup_plays.extend(self.image['setup'])
 
             with open(setup_file, 'w') as outfile:
                 yaml.dump(setup_plays, outfile)


### PR DESCRIPTION
This generalizes the images[i].setup command in config.json.

The playbook shall be given as a JSON array under the images[i].setup_plays key in config.json. This is possible because Ansible playbooks are YAML and can be represented as JSON.

Eventually, images[i].setup can be removed.