### PR TITLE
Run dnf commands together and remove cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM fedora:28
 
-RUN dnf update -y
-
-RUN dnf install -y \
+RUN dnf update -y && dnf install -y \
     ansible \
     git \
     python3-requests \
-    standard-test-roles
+    standard-test-roles && dnf clean all
 
 RUN useradd -m tester
 USER tester


### PR DESCRIPTION
The way docker caches images, it is recommended to remove the package
cache to ensure that later steps do not use outdated cache files and to
reduce the image size. To avoid re-downloads of the cache, run all
commands at once.