### PR TITLE
Allow to whitelist uploading and create simple HTML to check logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ accessible URL for these results. For example:
     {
       "name": "fedora-27",
       "source": "https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2",
+      "upload_results": true,
       "setup": "sudo dnf install -yq python2 python2-dnf libselinux-python"
     },
     {
       "name": "fedora-28",
       "source": "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2",
+      "upload_results": true,
       "setup": [
         {
           "name": "Setup",
@@ -52,11 +54,13 @@ accessible URL for these results. For example:
     },
     {
       "name": "centos-6",
-      "source": "https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud-1804_02.qcow2c"
+      "source": "https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud-1804_02.qcow2c",
+      "upload_results": true
     },
     {
       "name": "centos-7",
-      "source": "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1804_02.qcow2c"
+      "source": "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1804_02.qcow2c",
+      "upload_results": true
     }
   ],
   "results": {

--- a/test/run-tests
+++ b/test/run-tests
@@ -5,6 +5,7 @@ import argparse
 import datetime
 import fnmatch
 import glob
+import html
 import json
 import logging
 import os
@@ -364,6 +365,29 @@ def scp(source, destination, secrets):
     return result.returncode == 0
 
 
+def make_html(source_file):
+    links = {"index": ".", "ansible log": "ansible.log"}
+    html_file = source_file + ".html"
+
+    anchors = ""
+    for name, target in links.items():
+        a_html = "<a href='{}'>{}</a> ".format(html.escape(target),
+                                              html.escape(name))
+        anchors += a_html
+
+    with open(source_file) as ifile:
+        textdata = ifile.read()
+
+    html_code = """<pre>{}</pre>
+{}
+    """.format(html.escape(textdata), anchors)
+
+    with open(html_file, "w") as ofile:
+        ofile.write(html_code)
+
+    return html_file
+
+
 def handle_task(gh, args, config, task, dry_run=False):
     title = f'{HOSTNAME}: {task.owner}/{task.repo}: pull #{task.pull} '
     title += f'({task.head[:7]}) on {task.image["name"]}'
@@ -439,6 +463,7 @@ def handle_task(gh, args, config, task, dry_run=False):
         with open(local_test_log) as test_log:
             print(test_log.read())
     else:
+        make_html(local_test_log)
 
         if task.image.get("upload_results"):
             results_destination = config['results']['destination']
@@ -448,7 +473,7 @@ def handle_task(gh, args, config, task, dry_run=False):
             if scp(workdir, f'{results_destination}/{results_dir}',
                    args.secrets):
                 target_url = \
-                    f'{results_url}/{results_dir}/artifacts/test.log'
+                    f'{results_url}/{results_dir}/artifacts/test.log.html'
             else:
                 target_url = None
                 state = 'error'

--- a/test/run-tests
+++ b/test/run-tests
@@ -365,8 +365,6 @@ def scp(source, destination, secrets):
 
 
 def handle_task(gh, args, config, task, dry_run=False):
-    results_destination = config['results']['destination']
-    results_url = config['results']['public_url']
     title = f'{HOSTNAME}: {task.owner}/{task.repo}: pull #{task.pull} '
     title += f'({task.head[:7]}) on {task.image["name"]}'
     print('>>>', title)
@@ -433,19 +431,30 @@ def handle_task(gh, args, config, task, dry_run=False):
             description = 'Exception when running tests: ' + str(e)
 
     run('chmod', 'a+rX', workdir)
-    results_dir = f'{task.owner}-{task.repo}-{task.id_}-{timestamp}'
+
+    local_test_log = f"{artifactsdir}/test.log"
 
     if dry_run:
         print(f"Artifacts kept at: {artifactsdir}")
-        with open(f"{artifactsdir}/test.log") as test_log:
+        with open(local_test_log) as test_log:
             print(test_log.read())
     else:
-        if scp(workdir, f'{results_destination}/{results_dir}',
-               args.secrets):
-            target_url = f'{results_url}/{results_dir}/artifacts/test.log'
+
+        if task.image.get("upload_results"):
+            results_destination = config['results']['destination']
+            results_url = config['results']['public_url']
+            results_dir = f'{task.owner}-{task.repo}-{task.id_}-{timestamp}'
+
+            if scp(workdir, f'{results_destination}/{results_dir}',
+                   args.secrets):
+                target_url = \
+                    f'{results_url}/{results_dir}/artifacts/test.log'
+            else:
+                target_url = None
+                state = 'error'
         else:
             target_url = None
-            state = 'error'
+
         # FIXME: workdir might be kept when python crashes
         shutil.rmtree(workdir)
 


### PR DESCRIPTION
Requiring whitlelisting of test results' uploads allows to introduce images for which no logs are uploaded. The simple HTML allows to easier access other log files.