### PR TITLE
Print message from GitHub in HTTPError handling

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -103,6 +103,13 @@ def handle_transient_httperrors(error):
         print(f">>> Rate limiting hit, waiting for {int(timeout)} seconds...")
         time.sleep(timeout)
     else:
+        # If this is error from GitHub, there should be some explanation in response
+        # content. Try to print it.
+        try:
+            print("E: GitHub: " + error.response.json()["message"])
+        except Exception:
+            pass
+
         return False
 
     return True


### PR DESCRIPTION
When handling HTTPErrors, if no other action is taken, try to
print message which is usually present in responses from GitHub.

Related: https://github.com/linux-system-roles/test-harness/issues/55