### PR TITLE
Fix use of CacheControl

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -25,6 +25,7 @@ import urllib.request
 
 import requests
 import cachecontrol
+import cachecontrol.heuristics
 import yaml
 
 HOSTNAME = socket.gethostname()
@@ -166,6 +167,20 @@ class redirect_output:  # pylint: disable=invalid-name
 
         sys.stdout = self.oldout
         sys.stderr = self.olderr
+
+
+class DontCacheStatuses(cachecontrol.heuristics.BaseHeuristic):
+    """
+    'Heuristics' for preventing caching of statuses.
+    """
+
+    def update_headers(self, response):
+        # We need to remove 'max-age' from cache-control
+        # TODO: figure out a way to discern responses for statuses query
+        return {"cache-control": "private"}
+
+    def warning(self, response):
+        pass
 
 
 def run(*argv, env=None, check=True, cwd=None):
@@ -790,7 +805,10 @@ def main():
     # Requests on keep-alive connections fail when the remote has closed a
     # connection before we've noticed and sent another request. Thus,
     # always retry sending requests once.
-    gh.mount("https://", cachecontrol.CacheControlAdapter(max_retries=1))
+    gh.mount(
+        "https://",
+        cachecontrol.CacheControlAdapter(max_retries=1, heuristic=DontCacheStatuses()),
+    )
 
     printed_waiting = False
 

--- a/test/run-tests
+++ b/test/run-tests
@@ -775,7 +775,7 @@ def main():
         images = config["images"]
         repos = [r.split("/") for r in config.get("repositories", [])]
 
-    gh = cachecontrol.CacheControl(Session("https://api.github.com"))
+    gh = Session("https://api.github.com")
     gh.headers.update(
         {
             "Accept": "application/vnd.github.v3+json",
@@ -786,10 +786,11 @@ def main():
     if token:
         gh.headers.update({"Authorization": f"token {token}"})
 
+    # Use CacheControl.
     # Requests on keep-alive connections fail when the remote has closed a
     # connection before we've noticed and sent another request. Thus,
     # always retry sending requests once.
-    gh.mount("https://", requests.adapters.HTTPAdapter(max_retries=1))
+    gh.mount("https://", cachecontrol.CacheControlAdapter(max_retries=1))
 
     printed_waiting = False
 


### PR DESCRIPTION
CacheControl works as an adapter inheriting from HTTPAdapter.
Use it as an adapter.