### PR TITLE
Container: Specify registry for container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM docker.io/library/fedora:28
 
 RUN dnf update -y && dnf install -y \
     ansible \


### PR DESCRIPTION
To avoid name squatting attacks/problems it is necessary to specify the
container registry when specifying a container image. Otherwise an image
with the same name from a different registry could be obtained.

References: https://raesene.github.io/blog/2019/09/25/typosquatting-in-a-multi-registry-world/