### PR TITLE
Use Ansible for deployment; use BuildConfig for building

### DIFF
--- a/add-staging-tag
+++ b/add-staging-tag
@@ -8,5 +8,5 @@ spec:
     - name: staging
       from:
         kind: DockerImage
-        name: docker.io/linuxsystemroles/test-harness:staging
+        name: linux-system-roles:staging
 '

--- a/ansible/openshift-playbook.yml
+++ b/ansible/openshift-playbook.yml
@@ -1,0 +1,90 @@
+---
+- name: Configure OpenShift deployment for linux-system-roles CI testing
+  hosts: localhost
+  vars:
+    test_harness_namespace: lsr-test-harness
+    test_harness_sa: "system:serviceaccount:{{ test_harness_namespace }}:tester"
+    test_harness_need_node_selector: true
+    test_harness_run_as_root: true
+    test_harness_node_selector:
+      system-roles-ci: "true"
+    test_harness_use_staging: true
+    test_harness_use_production: false
+  tasks:
+
+  - name: Ensure python openshift client package is installed
+    package:
+      name: python3-openshift
+      state: present
+    become: true
+
+  - fail:
+      msg: You must set "test_harness_secrets_dir" in your inventory
+    when: test_harness_secrets_dir is not defined
+
+  - fail:
+      msg: You must set "test_harness_config_dir" in your inventory
+    when: test_harness_config_dir is not defined
+
+  - fail:
+      msg: You must set "test_harness_scc" in your inventory
+    when: test_harness_scc is not defined
+
+  # hmm - may need admin access for this
+  - name: Ensure testing namespace is present
+    k8s:
+      name: "{{ test_harness_namespace }}"
+      api_version: v1
+      kind: Namespace
+      state: present
+    ignore_errors: true
+
+  - name: Check if testing namespace is present
+    k8s_info:
+      name: "{{ test_harness_namespace }}"
+      api_version: v1
+      kind: Namespace
+    register: register_namespace_present
+    changed_when: false
+
+  - fail:
+      msg: The namespace "{{ test_harness_namespace }}" does not exist
+    when: not register_namespace_present.resources | d([])
+
+  - k8s_info:
+      api_version: security.openshift.io/v1
+      kind: SecurityContextConstraints
+      name: "{{ test_harness_scc }}"
+      namespace: "{{ test_harness_namespace }}"
+    register: register_scc
+    changed_when: false
+
+  - name: Ensure tester sa is in test scc
+    command: oc -n {{ test_harness_namespace }} patch scc/{{ test_harness_scc }} --type json \
+      -p '[{"op":"add","path":"/users/-","value":"{{ test_harness_sa }}"}]'
+    when: test_harness_sa not in register_scc.resources[0].users
+
+  - name: Ensure secrets are present
+    include_tasks: tasks/create-secrets.yml
+
+  - name: Ensure staging is set up
+    include_tasks: tasks/setup-ci-environ.yml
+    vars:
+      __test_harness_environ: staging
+      __test_harness_cm_name: linux-system-roles-staging
+      __test_harness_cm_file: config-staging.json
+      __test_harness_ci_obj_file: ../openshift-objects-staging.yml
+      __test_harness_dc: linux-system-roles-staging
+      __test_harness_bc: linux-system-roles-staging
+    when: test_harness_use_staging|bool
+
+  - name: Ensure production is set up
+    include_tasks: tasks/setup-ci-environ.yml
+    vars:
+      __test_harness_environ: production
+      __test_harness_cm_name: linux-system-roles
+      __test_harness_cm_file: config.json
+      __test_harness_ci_obj_file: ../openshift-objects.yml
+      __test_harness_dc: linux-system-roles
+      __test_harness_bc: linux-system-roles
+    when: test_harness_use_production|bool

--- a/ansible/tasks/create-configmap.yml
+++ b/ansible/tasks/create-configmap.yml
@@ -1,0 +1,26 @@
+---
+- name: Create temp file for config
+  tempfile:
+    state: file
+    suffix: lsr.yml
+  register: config_tempfile
+  changed_when: false
+
+- name: Generate config file
+  shell: oc -n {{ test_harness_namespace }} create configmap {{ __test_harness_cm_name }} \
+    --from-file=config.json={{ test_harness_config_dir }}/{{ __test_harness_cm_file }} --dry-run=true \
+    --output=yaml > {{ config_tempfile.path }}
+  changed_when: false
+
+- name: Ensure configmap is present
+  k8s:
+    src: "{{ config_tempfile.path }}"
+    namespace: "{{ test_harness_namespace }}"
+    state: present
+    apply: true
+
+- name: Remove config file
+  file:
+    state: absent
+    path: "{{ config_tempfile.path }}"
+  changed_when: false

--- a/ansible/tasks/create-secrets.yml
+++ b/ansible/tasks/create-secrets.yml
@@ -1,0 +1,25 @@
+---
+- name: Create temp file for secrets
+  tempfile:
+    state: file
+    suffix: lsr.yml
+  register: secrets_tempfile
+  changed_when: false
+
+- name: Generate secrets file
+  shell: oc -n {{ test_harness_namespace }} create secret generic secrets \
+    --from-file={{ test_harness_secrets_dir }} --dry-run=true \
+    --output=yaml > {{ secrets_tempfile.path }}
+  changed_when: false
+
+- name: Ensure secrets are present
+  k8s:
+    src: "{{ secrets_tempfile.path }}"
+    namespace: "{{ test_harness_namespace }}"
+    state: present
+
+- name: Remove secrets file
+  file:
+    state: absent
+    path: "{{ secrets_tempfile.path }}"
+  changed_when: false

--- a/ansible/tasks/fixup-dc.yml
+++ b/ansible/tasks/fixup-dc.yml
@@ -1,0 +1,77 @@
+---
+- k8s_info:
+    api_version: v1
+    kind: DeploymentConfig
+    name: "{{ __test_harness_dc }}"
+    namespace: "{{ test_harness_namespace }}"
+  register: register_lsr_staging_dc
+  changed_when: false
+
+- name: Ensure dc has node selector - replace existing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"replace","path":"/spec/template/spec/nodeSelector","value":{{ test_harness_node_selector }} }]'
+  when:
+    - test_harness_need_node_selector|bool
+    - "'nodeSelector' in register_lsr_staging_dc.resources[0].spec.template.spec"
+    - register_lsr_staging_dc.resources[0].spec.template.spec.nodeSelector != test_harness_node_selector
+
+- name: Ensure dc has node selector - add missing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"add","path":"/spec/template/spec/nodeSelector","value":{{ test_harness_node_selector }} }]'
+  when:
+    - test_harness_need_node_selector|bool
+    - "'nodeSelector' not in register_lsr_staging_dc.resources[0].spec.template.spec"
+
+- name: Ensure dc has no fsGroup
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"remove","path":"/spec/template/spec/containers/0/securityContext","value":"fsGroup"}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'fsGroup' in register_lsr_staging_dc.resources[0].spec.template.spec.containers[0].securityContext"
+
+- name: Ensure runAsUser 0 is set - replace existing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"replace","path":"/spec/template/spec/securityContext","value":{"runAsUser":0}}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'securityContext' in register_lsr_staging_dc.resources[0].spec.template.spec"
+    - "'runAsUser' in register_lsr_staging_dc.resources[0].spec.template.spec.securityContext"
+    - register_lsr_staging_dc.resources[0].spec.template.spec.securityContext.runAsUser != 0
+
+- name: Ensure runAsUser 0 is set - add missing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"add","path":"/spec/template/spec/securityContext","value":{"runAsUser":0}}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'securityContext' not in register_lsr_staging_dc.resources[0].spec.template.spec"
+    - "'runAsUser' not in register_lsr_staging_dc.resources[0].spec.template.spec.securityContext"
+
+- name: Ensure secret permission set correctly - replace existing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"replace","path":"/spec/template/spec/volumes/0/secret/defaultMode","value":256}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'defaultMode' in register_lsr_staging_dc.resources[0].spec.template.spec.volumes[0].secret"
+    - register_lsr_staging_dc.resources[0].spec.template.spec.volumes[0].secret.defaultMode != 256
+
+- name: Ensure secret permission set correctly - add missing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"add","path":"/spec/template/spec/volumes/0/secret/defaultMode","value":256}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'defaultMode' not in register_lsr_staging_dc.resources[0].spec.template.spec.volumes[0].secret"
+
+- name: Ensure config permission set correctly - replace existing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"replace","path":"/spec/template/spec/volumes/1/configMap/defaultMode","value":420}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'defaultMode' in register_lsr_staging_dc.resources[0].spec.template.spec.volumes[1].configMap"
+    - register_lsr_staging_dc.resources[0].spec.template.spec.volumes[1].configMap.defaultMode != 420
+
+- name: Ensure config permission set correctly - add missing
+  command: oc -n {{ test_harness_namespace }} patch dc/{{ __test_harness_dc }} --type json \
+    -p '[{"op":"add","path":"/spec/template/spec/volumes/1/configMap/defaultMode","value":420}]'
+  when:
+    - test_harness_run_as_root|bool
+    - "'defaultMode' not in register_lsr_staging_dc.resources[0].spec.template.spec.volumes[1].configMap"

--- a/ansible/tasks/setup-ci-environ.yml
+++ b/ansible/tasks/setup-ci-environ.yml
@@ -1,0 +1,29 @@
+---
+  - name: Ensure {{ __test_harness_environ }} configmap is present
+    include_tasks: create-configmap.yml
+
+  # NOTE: This is not idempotent - it will report changed every time
+  # seems to be a problem in the k8s module
+  - name: Ensure {{ __test_harness_environ }} objects are present
+    k8s:
+      src: "{{ __test_harness_ci_obj_file }}"
+      namespace: "{{ test_harness_namespace }}"
+      state: present
+
+  - name: Ensure node selectors and/or run as root for {{ __test_harness_environ }}
+    when: test_harness_need_node_selector|bool or test_harness_run_as_root|bool
+    include_tasks: fixup-dc.yml
+
+  - name: Initiate build of {{ __test_harness_environ }} image
+    command: oc -n {{ test_harness_namespace }} start-build --follow {{ __test_harness_bc }}
+    changed_when: false
+
+  - name: Get {{ __test_harness_environ }} dc rollout status
+    command: oc -n {{ test_harness_namespace }} rollout status --watch=false dc/{{ __test_harness_dc }}
+    register: register_dc_rollout
+    changed_when: false
+
+  - name: Ensure latest {{ __test_harness_environ }} dc is rolled out
+    command: oc -n {{ test_harness_namespace }} rollout latest dc/{{ __test_harness_dc }}
+    when: register_dc_rollout.stdout is match("^replication controller.*successfully rolled out$")
+    changed_when: false

--- a/openshift-objects-staging.yml
+++ b/openshift-objects-staging.yml
@@ -1,6 +1,26 @@
 apiVersion: v1
 kind: List
 items:
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: linux-system-roles-staging
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: linux-system-roles:staging
+      resources: {}
+      source:
+        git:
+          uri: https://github.com/linux-system-roles/test-harness
+          ref: master
+        type: Git
+      strategy:
+        type: Docker
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:
@@ -30,7 +50,7 @@ items:
           restartPolicy: Always
           containers:
             - name: linux-system-roles-staging
-              image: docker.io/linuxsystemroles/test-harness:staging
+              image: linux-system-roles:staging
               volumeMounts:
                 - name: secrets
                   mountPath: /secrets

--- a/openshift-objects.yml
+++ b/openshift-objects.yml
@@ -14,11 +14,31 @@ items:
         - name: latest
           from:
             kind: DockerImage
-            name: docker.io/linuxsystemroles/test-harness
+            name: linux-system-roles:latest
         - name: staging
           from:
             kind: DockerImage
-            name: docker.io/linuxsystemroles/test-harness:staging
+            name: linux-system-roles:staging
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: linux-system-roles
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: linux-system-roles:latest
+      resources: {}
+      source:
+        git:
+          uri: https://github.com/linux-system-roles/test-harness
+          ref: master
+        type: Git
+      strategy:
+        type: Docker
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:
@@ -48,7 +68,7 @@ items:
           restartPolicy: Always
           containers:
             - name: linux-system-roles
-              image: docker.io/linuxsystemroles/test-harness
+              image: linux-system-roles:latest
               volumeMounts:
                 - name: secrets
                   mountPath: /secrets


### PR DESCRIPTION
Added a playbook for deploying the CI environment to an
OpenShift cluster.

```
$ ansible-playbook -e test_harness_secrets_dir=$SECRETS_PATH \
    -e test_harness_config_dir=$CONFIG_PATH \
    -e test_harness_scc=$SCC_NAME \
    ansible/openshift-playbook.yml
```

Parameters:
* `test_harness_secrets_dir` - Required - See `SECRETS_PATH`
* `test_harness_config_dir` - Required - See `CONFIG_PATH`
* `test_harness_scc` - Required - See `SCC_NAME`
* `test_harness_namespace` - Default `lsr-test-harness`
* `test_harness_sa` - Default `system:serviceaccount:{{ test_harness_namespace }
}:tester`
* `test_harness_need_node_selector` - Default `true`
* `test_harness_run_as_root` - Default `true`
* `test_harness_node_selector` - Default `{"system-roles-ci": "true"}`
* `test_harness_use_staging` - Default `true`
* `test_harness_use_production` - Default `false`

By default, this will deploy and/or update the staging environment
since`test_harness_use_staging: true`.  It will also change the
DeploymentConfig to use the nodeSelector above, and will configure the
DeploymentConfig to run as root.  If you want to deploy to production, you must
explicitly set `test_harness_use_production` to `true`.

I also added BuildConfigs for the staging and production images so
that we do not have a dependency on `docker.io` or other external
image registry.  I updated the `image` and `imagestream` definitions
to reflect this.
