### PR TITLE
use 8 pods in production

### DIFF
--- a/openshift-objects.yml
+++ b/openshift-objects.yml
@@ -44,7 +44,7 @@ items:
     metadata:
       name: linux-system-roles
     spec:
-      replicas: 1
+      replicas: 8
       selector:
         name: linux-system-roles
       triggers:


### PR DESCRIPTION
set number of replicas for production to `8`.  This is how many
pods will run in production.