### PR TITLE
pre-flight-checks: split checks to two files

### DIFF
--- a/ansible/openshift-playbook.yml
+++ b/ansible/openshift-playbook.yml
@@ -10,8 +10,11 @@
       system-roles-ci: "true"
   tasks:
 
+  - name: Openshift pre-flight checks
+    include_tasks: tasks/pre-flight-checks-openshift.yml
+
   - name: Pre-flight checks
-    include_tasks: tasks/pre-flight-checks.yml
+    include_tasks: tasks/pre-flight-checks-general.yml
 
   # hmm - may need admin access for this
   - name: Ensure testing namespace is present

--- a/ansible/tasks/pre-flight-checks-general.yml
+++ b/ansible/tasks/pre-flight-checks-general.yml
@@ -1,15 +1,3 @@
-  - name: See if python openshift client package is installed
-    command: rpm -q python3-openshift
-    ignore_errors: true
-    register: test_harness_register_pyoc
-
-  - fail:
-      msg: You must install the python3-openshift package in order to use the k8s modules e.g. on Fedora 'sudo dnf -y install python3-openshift'
-    when: test_harness_register_pyoc is failed
-
-  - name: See if logged into an OpenShift cluster
-    command: oc whoami
-
   - name: Get current git branch
     command: git rev-parse --abbrev-ref HEAD
     register: test_harness_register_git_branch

--- a/ansible/tasks/pre-flight-checks-openshift.yml
+++ b/ansible/tasks/pre-flight-checks-openshift.yml
@@ -1,0 +1,11 @@
+  - name: See if python openshift client package is installed
+    command: rpm -q python3-openshift
+    ignore_errors: true
+    register: test_harness_register_pyoc
+
+  - fail:
+      msg: You must install the python3-openshift package in order to use the k8s modules e.g. on Fedora 'sudo dnf -y install python3-openshift'
+    when: test_harness_register_pyoc is failed
+
+  - name: See if logged into an OpenShift cluster
+    command: oc whoami


### PR DESCRIPTION
The PR splits pre-flight-checks to two files: one for general usage and the second one for openshift specifically.  
It will be needed for creating openstack deploy playbook