### PR TITLE
disable centos7/ansible 2.7 testing for now

### DIFF
--- a/ansible/openshift-playbook.yml
+++ b/ansible/openshift-playbook.yml
@@ -62,6 +62,7 @@
       __test_harness_ci_obj_file: ../openshift-objects-staging.yml
       __test_harness_dc: linux-system-roles-staging
       __test_harness_bc: linux-system-roles-staging
+      __test_harness_env_is_enabled: true
     when: test_harness_use_staging | d(false) | bool
 
   - name: Ensure production is set up
@@ -73,6 +74,7 @@
       __test_harness_ci_obj_file: ../openshift-objects.yml
       __test_harness_dc: linux-system-roles
       __test_harness_bc: linux-system-roles
+      __test_harness_env_is_enabled: true
     when: test_harness_use_production | d(false) | bool
 
   - name: Ensure centos7 staging is set up
@@ -84,6 +86,7 @@
       __test_harness_ci_obj_file: ../openshift-objects-staging.yml
       __test_harness_dc: linux-system-roles-centos7-staging
       __test_harness_bc: linux-system-roles-centos7-staging
+      __test_harness_env_is_enabled: false
     when: test_harness_use_staging | d(false) | bool
 
   - name: Ensure centos7 production is set up
@@ -95,4 +98,5 @@
       __test_harness_ci_obj_file: ../openshift-objects.yml
       __test_harness_dc: linux-system-roles-centos7
       __test_harness_bc: linux-system-roles-centos7
+      __test_harness_env_is_enabled: false
     when: test_harness_use_production | d(false) | bool

--- a/ansible/tasks/setup-ci-environ.yml
+++ b/ansible/tasks/setup-ci-environ.yml
@@ -17,13 +17,16 @@
   - name: Initiate build of {{ __test_harness_environ }} image
     command: oc -n {{ test_harness_namespace }} start-build --follow {{ __test_harness_bc }}
     changed_when: false
+    when: __test_harness_env_is_enabled
 
   - name: Get {{ __test_harness_environ }} dc rollout status
     command: oc -n {{ test_harness_namespace }} rollout status --watch=false dc/{{ __test_harness_dc }}
     register: register_dc_rollout
     changed_when: false
+    when: __test_harness_env_is_enabled
 
   - name: Ensure latest {{ __test_harness_environ }} dc is rolled out
     command: oc -n {{ test_harness_namespace }} rollout latest dc/{{ __test_harness_dc }}
     when: register_dc_rollout.stdout is match("^replication controller.*successfully rolled out$")
     changed_when: false
+    when: __test_harness_env_is_enabled

--- a/openshift-objects-staging.yml
+++ b/openshift-objects-staging.yml
@@ -98,7 +98,7 @@ items:
     metadata:
       name: linux-system-roles-centos7-staging
     spec:
-      replicas: 1
+      replicas: 0
       selector:
         name: linux-system-roles-centos7-staging
       triggers:

--- a/openshift-objects.yml
+++ b/openshift-objects.yml
@@ -130,7 +130,7 @@ items:
     metadata:
       name: linux-system-roles-centos7
     spec:
-      replicas: 8
+      replicas: 0
       selector:
         name: linux-system-roles-centos7
       triggers:


### PR DESCRIPTION
do not deploy the centos/ansible 2.7 testing environment

LSR CI testing has a problem with hitting the github api ratelimit.
This is due to the design of the run-tests script.
Adding another deployment for ansible 2.7 testing just makes that
problem worse.  It seems that having another separate deployment
for ansible 2.7 is not the right approach.  We are in the process
of evaluating CI options.  If we stick with the current approach,
one alternative would be for the current deployment to launch
ansible-playbook for multiple versions of ansible.

However, this code may be useful, so for now not deleting it completely,
but leaving it in as disabled.