### PR TITLE
config and secrets dirs should be playbook vars

### DIFF
--- a/ansible/openshift-playbook.yml
+++ b/ansible/openshift-playbook.yml
@@ -2,6 +2,8 @@
 - name: Configure OpenShift deployment for linux-system-roles CI testing
   hosts: localhost
   vars:
+    test_harness_secrets_dir: "{{ '$HOME/rhel-system-roles/test-harness-config/secrets' | expandvars }}"
+    test_harness_config_dir: "{{ '$HOME/rhel-system-roles/test-harness-config/config' | expandvars }}"
     test_harness_namespace: lsr-test-harness
     test_harness_sa: "system:serviceaccount:{{ test_harness_namespace }}:tester"
     test_harness_need_node_selector: true

--- a/ansible/tasks/pre-flight-checks-general.yml
+++ b/ansible/tasks/pre-flight-checks-general.yml
@@ -13,14 +13,6 @@
       msg: You have unstaged changes in your local git branch [{{ test_harness_git_branch }}].  Please commit before deploying.
     when: test_harness_register_git_status.stdout != ""
 
-  - set_fact:
-      test_harness_secrets_dir: "{{ '$HOME/rhel-system-roles/test-harness-config/secrets' | expandvars }}"
-    when: test_harness_secrets_dir is not defined
-
-  - set_fact:
-      test_harness_config_dir: "{{ '$HOME/rhel-system-roles/test-harness-config/config' | expandvars }}"
-    when: test_harness_config_dir is not defined
-
   - fail:
       msg: You may need to set or correct "test_harness_secrets_dir" in your inventory - [{{ test_harness_secrets_dir }}] not found
     when: not test_harness_secrets_dir is directory


### PR DESCRIPTION
test_harness_secrets_dir and test_harness_config_dir should be set
via the playbook vars, not via set_fact in the flight check tasks.