### PR TITLE
buildconfig must output to staging tag if not production

### DIFF
--- a/openshift-objects.yml
+++ b/openshift-objects.yml
@@ -27,7 +27,10 @@ items:
       output:
         to:
           kind: ImageStreamTag
-          name: {{ __test_harness_imgstream_name | d("linux-system-roles") }}:latest
+          name: {{ __test_harness_imgstream_name | d("linux-system-roles") }}:{{
+            "latest" if test_harness_git_branch | d("production") == "production"
+            else "staging"
+          }}
       resources: {}
       source:
         git:


### PR DESCRIPTION
The buildconfig must output to the "staging" imagestream tag if
not being used in production.