### PR TITLE
increase num of statuses to 99 - 60 is too small

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -1040,8 +1040,8 @@ def main():
     parser.add_argument(
         "--max-num-statuses",
         type=int,
-        default=int(os.environ.get("TEST_HARNESS_MAX_NUM_STATUSES", "60")),
-        help="Number of statuses to retrieve - default 60 - github default is 30",
+        default=int(os.environ.get("TEST_HARNESS_MAX_NUM_STATUSES", "99")),
+        help="Number of statuses to retrieve - default 99 - github default is 30",
     )
     parser.add_argument(
         "--backend",


### PR DESCRIPTION
Seeing error messages like this in production:
```
ERROR: Total number of statuses 61 exceeds max_num_statuses 60 statuses for xxx - please increase max_num_statuses
```
I have temporarily fixed production by using the env var setting, but
this will be wiped out at the next redeploy.