### PR TITLE
Use deploy_replicas* also for centos7 deployments

### DIFF
--- a/ansible/openshift-playbook.yml
+++ b/ansible/openshift-playbook.yml
@@ -115,7 +115,7 @@
         __test_harness_bc: linux-system-roles-centos7-staging
         __test_harness_secret_name: secrets-staging
         __test_harness_ghtoken_file: github-token-staging
-        __test_harness_deploy_replicas: 1
+        __test_harness_deploy_replicas: "{{ test_harness_deploy_replicas_staging | d(1) }}"
         __test_harness_dockerfile: ../Dockerfile.centos7
         __test_harness_dockerfile_from: "centos:7"
         __test_harness_dockerfile_pre_tester: "{{ test_harness_dockerfile_pre_tester }}"
@@ -136,7 +136,7 @@
         __test_harness_bc: linux-system-roles-centos7
         __test_harness_secret_name: secrets
         __test_harness_ghtoken_file: github-token
-        __test_harness_deploy_replicas: 1
+        __test_harness_deploy_replicas: "{{ test_harness_deploy_replicas | d(1) }}"
         __test_harness_dockerfile: ../Dockerfile.centos7
         __test_harness_dockerfile_from: "centos:7"
         __test_harness_dockerfile_pre_tester: "{{ test_harness_dockerfile_pre_tester }}"


### PR DESCRIPTION
Synchronizes centos7 deployments with the standard deployments. But keep the default for centos7 production as 1 to avoid a thundering herd of production pods when the variable is unset (default for standard production is 8).