### PR TITLE
Derive image URL from compose URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf update -y && dnf install -y \
     git \
     python3-requests \
     python3-CacheControl \
+    python3-productmd \
     standard-test-roles && dnf clean all
 
 RUN useradd -m tester

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ RUN yum update -y && PKGS="centos-release-ansible-28 centos-release-scl-rh" && \
     PKGS="rh-git218 python3-pip standard-test-roles python2-fmf seabios-bin" && \
     yum -y install $PKGS && rpm -V $PKGS && \
     yum clean all && \
-    pip3 install cachecontrol
+    pip3 install cachecontrol productmd
 
 RUN curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64
 RUN chmod +x /usr/local/bin/dumb-init

--- a/test/compose2image.py
+++ b/test/compose2image.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+import sys
+import productmd.compose
+
+
+def composeurl2images(
+    composeurl, desiredarch, desiredvariant=None, desiredsubvariant=None
+):
+    # we will need to join it with a relative path component
+    if composeurl.endswith("/"):
+        composepath = composeurl
+    else:
+        composepath = composeurl + "/"
+
+    compose = productmd.compose.Compose(composepath)
+
+    candidates = set()
+
+    for variant, arches in compose.images.images.items():
+        for arch in arches:
+            if arch == desiredarch:
+                for image in arches[arch]:
+                    if image.type == "qcow2":
+                        candidates.add((image, variant, image.subvariant))
+
+    # variant and subvariant are used only as a hint
+    # to disambiguate if multiple images were found
+    if len(candidates) > 1:
+        if desiredvariant:
+            variantmatch = {
+                imginfo for imginfo in candidates if imginfo[1] == desiredvariant
+            }
+            if len(variantmatch) > 0:
+                candidates = variantmatch
+    if len(candidates) > 1:
+        if desiredsubvariant:
+            subvariantmatch = {
+                imginfo for imginfo in candidates if imginfo[2] == desiredsubvariant
+            }
+            if len(subvariantmatch) > 0:
+                candidates = subvariantmatch
+
+    return [(composepath + qcow2[0].path) for qcow2 in candidates]
+
+
+if __name__ == "__main__":
+    USAGE = "Usage: %s <composeurl> <arch> <variant>" % sys.argv[0]
+
+    # sanity-check arguments
+    if len(sys.argv) != 4:
+        print("Invalid arguments.")
+        print(USAGE)
+        sys.exit(2)
+
+    composeurl = sys.argv[1]
+    arch = sys.argv[2]
+    variant = sys.argv[3]
+    # subvariant could be added if needed
+    imageurls = composeurl2images(composeurl, arch, variant)
+    if len(imageurls) == 1:
+        print(imageurls[0])
+    else:
+        sys.exit("multiple images found: {}".format(imageurls))

--- a/test/run-tests
+++ b/test/run-tests
@@ -33,6 +33,7 @@ import yaml
 # use LooseVersion to handle alphas, betas, other pre-release versions
 from distutils.version import LooseVersion
 from distutils.util import strtobool
+from compose2image import composeurl2images
 
 HOSTNAME = socket.gethostname()
 
@@ -328,6 +329,30 @@ class Task:
     def __str__(self):
         return f"task {self.owner}/{self.repo}/{self.pull}:{self.image['name']}"
 
+    def get_url(self):
+        source = self.image.get("source")
+        if source:
+            return source
+        compose_url = self.image.get("compose")
+        if compose_url:
+            variant = self.image.get("variant")
+            image_urls = composeurl2images(compose_url, "x86_64", variant)
+            if len(image_urls) == 1:
+                return image_urls[0]
+            else:
+                if image_urls:
+                    logging.error(
+                        f"ERROR: Multiple images found: {image_urls}"
+                        "in compose {compose_url}"
+                    )
+                else:
+                    logging.error(f"ERROR: no image found in compose {compose_url}")
+        else:
+            logging.error(
+                "ERROR: neither source nor compose specified"
+                f"in image {self.image['name']}"
+            )
+
     def run(
         self, artifactsdir, private_artifactsdir, cachedir, backend, inventory=None
     ):
@@ -341,7 +366,10 @@ class Task:
             inventory = self.inventory
 
         if backend == KVM_BACKEND:
-            image_path = fetch_image(self.image["source"], cachedir)
+            image_url = self.get_url()
+            if not image_url:
+                return None
+            image_path = fetch_image(image_url, cachedir)
             if not image_path:
                 return None
 
@@ -665,12 +693,12 @@ def choose_task(gh, repos, images, config, ansible_id, args):
                 if check_commit_needs_testing(status, commands):
                     task = Task(owner, repo, number, head, image)
                     logging.debug(
-                        f"Testing PR {pull['url']} with image {image['source']}"
+                        f"Testing PR {pull['url']} with image {image['name']}"
                     )
                     return task
                 else:
                     logging.debug(
-                        f"Not testing PR {pull['url']} with image {image['source']}"
+                        f"Not testing PR {pull['url']} with image {image['name']}"
                     )
             else:
                 logging.debug("No images to use for testing PR {}".format(pull["url"]))
@@ -1140,7 +1168,7 @@ def main():
         pattern_matched = False
         for pattern in image_patterns:
             if fnmatch.fnmatch(image["name"], pattern) or fnmatch.fnmatch(
-                image["source"], pattern
+                image.get("source", ""), pattern
             ):
                 pattern_matched = True
                 break

--- a/test/run-tests
+++ b/test/run-tests
@@ -343,7 +343,7 @@ class Task:
         if backend == KVM_BACKEND:
             image_path = fetch_image(self.image["source"], cachedir)
             if not image_path:
-                return False
+                return None
 
         with checkout_repository(
             self.owner, self.repo, f"pull/{self.pull}/head"


### PR DESCRIPTION
Can be used to support images whose URL is changing dynamically, like latest Fedora cloud images.

Introduces a new option "compose" in the image dictionary, which can be used instead of "source" and contains the compose URL.

Optionally it can be qualified by "variant" when the compose contains images of multiple variants and specifying only compose would be ambiguous.

Also properly report error when image can't be downloaded as an error not test failure.

Closes #15