### PR TITLE
RHELPLAN-60810 - Fixing a collection CI test failure - "__spec__ is None" if the role has module_utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ RUN dnf update -y && dnf install -y \
     python3-CacheControl \
     python3-productmd \
     python3-ruamel-yaml \
-    standard-test-roles && dnf clean all
+    standard-test-roles \
+    libnftnl nftables firewalld firewalld-filesystem \
+    python3-nftables ipset python3-firewall \
+    ipset-libs iptables \
+    NetworkManager python3-gobject-base wpa_supplicant && \
+    dnf clean all
 
 RUN useradd -m tester
 #EXTRAPRETESTER


### PR DESCRIPTION
https://github.com/linux-system-roles/test-harness/issues/124
CI tests with collections option fail with "__spec__ is None" if the
role has module_utils #124

To workaround the collections problem in ansible 2.9, pre-installing
the packages on the control node, which module_utils depend upon.

Packages module_utils depending upon:
1) Certificate
   libnftnl nftables firewalld firewalld-filesystem python3-nftables
   ipset python3-firewall ipset-libs iptables
2) Network
   NetworkManager python3-gobject-base wpa_supplicant
3) Storage
   none

The details about the ansible 2.9 problem are found in
https://github.com/ansible/ansible/issues/68361