### PR TITLE
RHELPLAN-42929 - Collections - script - add CI testing for collection

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -1081,8 +1081,6 @@ def handle_task(
             except requests.exceptions.HTTPError as err:
                 if not handle_transient_httperrors(err):
                     raise
-    if test_collections:
-        cleanup_collection_tempdirs()
 
     print()
 
@@ -1423,6 +1421,9 @@ def main():
         # At this point, we have (probably) printed other messages, so
         # reset printed_waiting
         printed_waiting = False
+
+    if test_collections:
+        cleanup_collection_tempdirs()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixing a bug introduced by commit 0e0e625413e43973d3f227b219f072e4e337f860
4) Cleanup the temporary dirs (conversion script, collection-converted
   role, and CI tests) at the end of run-tests

The location of cleanup code was wrong. It should have been placed at
the end of run-tests, but it was at the end of handle_task.