### PR TITLE
RHELPLAN-42929 - Collections - script - add CI testing for collection

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -893,10 +893,12 @@ def make_html(source_file):
 
 
 def cleanup_collection_tempdirs():
-    shutil.rmtree(os.environ["COLLECTION_TESTS_DEST_PATH"])
-    shutil.rmtree(os.environ["COLLECTION_DEST_PATH"])
+    if os.path.isdir(os.environ["COLLECTION_TESTS_DEST_PATH"]):
+        shutil.rmtree(os.environ["COLLECTION_TESTS_DEST_PATH"])
+    if os.path.isdir(os.environ["COLLECTION_DEST_PATH"]):
+        shutil.rmtree(os.environ["COLLECTION_DEST_PATH"])
     for pp in sys.path:
-        if str.startswith(pp, "/tmp/tmp"):
+        if os.path.isdir(pp) and str.startswith(pp, "/tmp/tmp"):
             shutil.rmtree(pp)
 
 


### PR DESCRIPTION
In the cleanup_collection_tempdirs function, delete the work directories
only when the directory exists.