### PR TITLE
nightly composes: Don't raise an exception if we find more images

### DIFF
--- a/test/compose2image.py
+++ b/test/compose2image.py
@@ -40,7 +40,9 @@ def composeurl2images(
             if len(subvariantmatch) > 0:
                 candidates = subvariantmatch
 
-    return [(composepath + qcow2[0].path) for qcow2 in candidates]
+    image_urls = [(composepath + qcow2[0].path) for qcow2 in candidates]
+    return sorted(image_urls, reverse=True)
+
 
 
 if __name__ == "__main__":
@@ -60,4 +62,5 @@ if __name__ == "__main__":
     if len(imageurls) == 1:
         print(imageurls[0])
     else:
+        # The first URL is the latest image
         sys.exit("multiple images found: {}".format(imageurls))

--- a/test/run-tests
+++ b/test/run-tests
@@ -364,16 +364,10 @@ class Task:
         if compose_url:
             variant = self.image.get("variant")
             image_urls = composeurl2images(compose_url, "x86_64", variant)
-            if len(image_urls) == 1:
+            if image_urls:
                 return image_urls[0]
             else:
-                if image_urls:
-                    logging.error(
-                        f"ERROR: Multiple images found: {image_urls}"
-                        "in compose {compose_url}"
-                    )
-                else:
-                    logging.error(f"ERROR: no image found in compose {compose_url}")
+                logging.error(f"ERROR: no image found in compose {compose_url}")
         else:
             logging.error(
                 "ERROR: neither source nor compose specified"


### PR DESCRIPTION
Use a less restrictive way to get an image from a compose URL.
The latest .qcow2 image is the last in the alphabet and first in the list of images.