### PR TITLE
Revert "RHELPLAN-60810 - Fixing a collection CI test failure - "__spec__ is None" if the role has module_utils"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,7 @@ RUN dnf update -y && dnf install -y \
     python3-CacheControl \
     python3-productmd \
     python3-ruamel-yaml \
-    standard-test-roles \
-    libnftnl nftables firewalld firewalld-filesystem \
-    python3-nftables ipset python3-firewall \
-    ipset-libs iptables \
-    NetworkManager python3-gobject-base wpa_supplicant && \
-    dnf clean all
+    standard-test-roles && dnf clean all
 
 RUN useradd -m tester
 #EXTRAPRETESTER


### PR DESCRIPTION
Reverting the change to preinstall packages for network and certificate roles.

This workaround is no longer needed once https://github.com/linux-system-roles/network/pull/330 and https://github.com/linux-system-roles/certificate/pull/71 are merged.

This reverts commit f3a9a3979bada386ed007c4920fd152426ba96d0.