### PR TITLE
use the getheader method rather than headers directly

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -273,7 +273,7 @@ def origurl(path):
 
 def get_metadata_from_url(url, metadata_key):
     with urllib.request.urlopen(url) as url_response:
-        return dict(url_response.getheaders())[metadata_key]
+        return url_response.getheader(metadata_key)
 
 
 def fetch_image(url, cache, label):


### PR DESCRIPTION
Use the `getheader` method instead of accessing `headers` directly.
The `getheader` method will do a case-insensitive lookup of the
requested header.
This solves the following problem:
```
Traceback (most recent call last):
  File "/test/run-tests", line 1035, in handle_task
    result = task.run(
  File "/test/run-tests", line 476, in run
    image_path = fetch_image(image_url, cachedir, self.image["name"])
  File "/test/run-tests", line 297, in fetch_image
    image_last_modified_by_src = get_metadata_from_url(url, "Last-Modified")
  File "/test/run-tests", line 276, in get_metadata_from_url
    return dict(url_response.getheaders())[metadata_key]
KeyError: 'Last-Modified'
```
The problem is that the server is returning the header as all lower case
`last-modified`.  This must have changed recently.