### PR TITLE
runtest: Add support for image names with two hyphens (rhel-8-y)

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -418,7 +418,7 @@ class Task:
         """
         Return True if image is supported. Otherwise False.
         """
-        distro, version = self.image["name"].split("-")
+        distro, version = self.image["name"].split("-")[:2]
         if version == "x":
             image_filename = os.path.basename(
                 urllib.parse.urlparse(self.get_url()).path


### PR DESCRIPTION
We currently support image formats like: `rhel-8` and `rhel-x`.

This PR adds support for the format "rhel-8-y". The `-y` part is ignored.