### PR TITLE
Use the same qcow2 inventory/VM provision script in centos7 as in Fedora

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -2,12 +2,15 @@ FROM registry.centos.org/centos/centos:7
 
 RUN yum update -y && PKGS="centos-release-ansible-28 centos-release-scl-rh" && \
     yum install -y $PKGS && rpm -V $PKGS && \
-    PKGS="ansible epel-release python2-jmespath rsync python-netaddr" && yum install -y $PKGS && rpm -V $PKGS && \
-    PKGS="rh-git218 python3-pip standard-test-roles python2-fmf seabios-bin" && \
+    PKGS="ansible epel-release rsync" && yum install -y $PKGS && rpm -V $PKGS && \
+    PKGS="python36-jmespath python36-netaddr python36-fmf" && yum install -y $PKGS && rpm -V $PKGS && \
+    PKGS="rh-git218 python3-pip standard-test-roles seabios-bin" && \
     yum -y install $PKGS && rpm -V $PKGS && \
     yum clean all && \
     pip3 install cachecontrol productmd
 
+RUN curl -s -o /usr/share/ansible/inventory/standard-inventory-qcow2 \
+    https://pagure.io/standard-test-roles/raw/ce0ce5eb049c886a0cb4ecbd3f4c9b409693ba4a/f/inventory/standard-inventory-qcow2
 
 RUN curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64
 RUN chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
Use python3.6 version of packages