### PR TITLE
netaddr and jmespath are for python2 for ansible

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,9 +1,9 @@
 FROM registry.centos.org/centos/centos:7
 
-RUN yum update -y && PKGS="centos-release-ansible-28 centos-release-scl-rh" && \
+RUN yum update -y && PKGS="centos-release-ansible-28 python2-jmespath python-netaddr centos-release-scl-rh" && \
     yum install -y $PKGS && rpm -V $PKGS && \
     PKGS="ansible epel-release rsync" && yum install -y $PKGS && rpm -V $PKGS && \
-    PKGS="python36-jmespath python36-netaddr python36-fmf" && yum install -y $PKGS && rpm -V $PKGS && \
+    PKGS="python36-fmf" && yum install -y $PKGS && rpm -V $PKGS && \
     PKGS="rh-git218 python3-pip standard-test-roles seabios-bin" && \
     yum -y install $PKGS && rpm -V $PKGS && \
     yum clean all && \


### PR DESCRIPTION
netaddr and jmespath are for python2 for ansible, not for python3
for the standard test script