### PR TITLE
do not report failure if only error is uploading results

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -1104,7 +1104,7 @@ def handle_task(
                 if scp(workdir, f"{results_destination}/{results_dir}", args.secrets):
                     target_url = f"{results_url}/{results_dir}/artifacts/test.log.html"
                 else:
-                    state = "error"
+                    logging.error("Could not upload results - check ssh keys")
                     description += ": Error uploading results"
             else:
                 # move files to private_artifactsdir


### PR DESCRIPTION
The github status should reflect the test status, not the result
uploading status.  Upload failures will be logged and reported
elsewhere.