### PR TITLE
Drop Ansible 2.8 from EL7 and install ansible 2.9 instead

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos/centos:7
 
-RUN yum update -y && PKGS="centos-release-ansible-28 python2-jmespath python-netaddr centos-release-scl-rh" && \
+RUN yum update -y && PKGS="centos-release-ansible-29 python2-jmespath python-netaddr centos-release-scl-rh" && \
     yum install -y $PKGS && rpm -V $PKGS && \
     PKGS="ansible epel-release rsync" && yum install -y $PKGS && rpm -V $PKGS && \
     PKGS="rh-git218 python3-pip standard-test-roles seabios-bin" && \


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197